### PR TITLE
Añade APIs de seguimiento de candidatos

### DIFF
--- a/backend/src/application/services/candidateService.ts
+++ b/backend/src/application/services/candidateService.ts
@@ -63,3 +63,58 @@ export const findCandidateById = async (id: number): Promise<Candidate | null> =
         throw new Error('Error al recuperar el candidato');
     }
 };
+
+export const getCandidatesByPosition = async (positionId: number) => {
+    const prisma = new (await import('@prisma/client')).PrismaClient();
+    // Buscar todas las aplicaciones para la posición dada, incluyendo candidato, paso actual y entrevistas
+    const applications = await prisma.application.findMany({
+        where: { positionId },
+        include: {
+            candidate: true,
+            interviewStep: true,
+            interviews: true
+        }
+    });
+    // Mapear la información requerida
+    return applications.map(app => {
+        // Calcular la puntuación media solo de entrevistas completadas (score !== null)
+        const completedInterviews = app.interviews.filter((i: any) => i.score !== null && i.score !== undefined);
+        const averageScore = completedInterviews.length > 0
+            ? completedInterviews.reduce((sum: number, i: any) => sum + i.score, 0) / completedInterviews.length
+            : null;
+        return {
+            id: app.candidate.id,
+            fullName: app.candidate.firstName + ' ' + app.candidate.lastName,
+            current_interview_step: app.interviewStep.name,
+            average_score: averageScore
+        };
+    });
+};
+
+export const updateApplicationStage = async (applicationId: number, stageId: number) => {
+    const prisma = new (await import('@prisma/client')).PrismaClient();
+    // Buscar la aplicación y la posición asociada
+    const application = await prisma.application.findUnique({
+        where: { id: applicationId },
+        include: { position: { select: { interviewFlowId: true } } }
+    });
+    if (!application) {
+        throw new Error('Aplicación no encontrada');
+    }
+    // Validar que el stage pertenezca al flujo de entrevistas de la posición
+    const stage = await prisma.interviewStep.findFirst({
+        where: {
+            id: stageId,
+            interviewFlowId: application.position.interviewFlowId
+        }
+    });
+    if (!stage) {
+        throw new Error('El stage no pertenece al flujo de entrevistas de la posición');
+    }
+    // Actualizar la aplicación
+    const updated = await prisma.application.update({
+        where: { id: applicationId },
+        data: { currentInterviewStep: stageId }
+    });
+    return updated;
+};

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { addCandidate, findCandidateById } from '../../application/services/candidateService';
+import { addCandidate, findCandidateById, getCandidatesByPosition, updateApplicationStage } from '../../application/services/candidateService';
 
 export const addCandidateController = async (req: Request, res: Response) => {
     try {
@@ -28,6 +28,33 @@ export const getCandidateById = async (req: Request, res: Response) => {
         res.json(candidate);
     } catch (error) {
         res.status(500).json({ error: 'Internal Server Error' });
+    }
+};
+
+export const getCandidatesByPositionController = async (req: Request, res: Response) => {
+    try {
+        const positionId = parseInt(req.params.id);
+        if (isNaN(positionId)) {
+            return res.status(400).json({ error: 'ID de posición inválido' });
+        }
+        const candidates = await getCandidatesByPosition(positionId);
+        res.json(candidates);
+    } catch (error) {
+        res.status(500).json({ error: 'Error al obtener los candidatos de la posición' });
+    }
+};
+
+export const updateApplicationStageController = async (req: Request, res: Response) => {
+    try {
+        const applicationId = parseInt(req.params.id);
+        const { stageId } = req.body;
+        if (isNaN(applicationId) || !stageId) {
+            return res.status(400).json({ error: 'Datos inválidos' });
+        }
+        const updated = await updateApplicationStage(applicationId, stageId);
+        res.json(updated);
+    } catch (error: any) {
+        res.status(400).json({ error: error.message || 'Error al actualizar la etapa' });
     }
 };
 

--- a/backend/src/routes/candidateRoutes.ts
+++ b/backend/src/routes/candidateRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { addCandidate, getCandidateById } from '../presentation/controllers/candidateController';
+import { addCandidate, getCandidateById, getCandidatesByPositionController, updateApplicationStageController } from '../presentation/controllers/candidateController';
 
 const router = Router();
 
@@ -18,5 +18,7 @@ router.post('/', async (req, res) => {
 });
 
 router.get('/:id', getCandidateById);
+router.get('/positions/:id/candidates', getCandidatesByPositionController);
+router.put('/:id/stage', updateApplicationStageController);
 
 export default router;

--- a/info.md
+++ b/info.md
@@ -1,0 +1,45 @@
+# LTI - Talent Tracking System | EN
+
+This project is a full-stack application with a React frontend and an Express backend using Prisma as an ORM. The frontend is started with Create React App, and the backend is written in TypeScript.
+
+## Explanation of Directories and Files
+
+- `backend/`: Contains the server-side code written in Node.js.
+  - `src/`: Contains the source code for the backend.
+    - `index.ts`: The entry point for the backend server.
+    - `application/`: Contains the application logic.
+    - `domain/`: Contains the business logic.
+    - `infrastructure/`: Contains code that communicates with the database.
+    - `presentation/`: Contains code related to the presentation layer (such as controllers).
+    - `routes/`: Contains the route definitions for the API.
+    - `tests/`: Contains test files.
+  - `prisma/`: Contains the Prisma schema file for ORM.
+  - `tsconfig.json`: TypeScript configuration file.
+- `frontend/`: Contains the client-side code written in React."
+  - `src/`: Contains the source code for the frontend.
+  - `public/`: Contains static files such as the HTML file and images.
+  - `build/`: Contains the production-ready build of the frontend.
+- `.env`: Contains the environment variables.
+- `docker-compose.yml`: Contains the Docker Compose configuration to manage your application's services.
+- `README.md`: This file contains information about the project and instructions on how to run it.
+
+## Project Structure
+
+The project is divided into two main directories: `frontend` and `backend`.
+
+### Frontend
+
+The frontend is a React application, and its main files are located in the src directory. The public directory contains static assets, and the build directory contains the production build of the application.
+
+### Backend
+
+The backend is an Express application written in TypeScript. The src directory contains the source code, divided into several subdirectories:
+
+- `application`: Contains the application logic.
+- `domain`: Contains the domain models.
+- `infrastructure`: Contains code related to the infrastructure.
+- `presentation`: Contains code related to the presentation layer.
+- `routes`: Contains the application routes.
+- `tests`: Contains the application tests.
+
+The `prisma` directory contains the Prisma schema.

--- a/prompts/prompts-DST.md
+++ b/prompts/prompts-DST.md
@@ -1,0 +1,97 @@
+# Prompts y Respuestas - Desarrollo de APIs DST
+
+## Prompt 1
+@info.md considera la información en el archivo info.md como la estructura del proyecto.
+
+Eres un expero desarollador backend, mecesito crear dos nuevas APIs, primero partiremos con una API para listar los candidatos de una aplicación en una interfaz tipo kanban.
+
+Lo que se requiere es lo siguiente:
+GET /positions/:id/candidates
+Este endpoint recogerá todos los candidatos en proceso para una determinada posición, es decir, todas las aplicaciones para un determinado positionID. Debe proporcionar la siguiente información básica:
+
+Nombre completo del candidato (de la tabla candidate).
+current_interview_step: en qué fase del proceso está el candidato (de la tabla application).
+La puntuación media del candidato. Recuerda que cada entrevist (interview) realizada por el candidato tiene un score
+
+Si tienes alguna duda preguntame antes de generar el código.
+
+**Respuesta:**
+¡Perfecto! Antes de generar el código, tengo algunas preguntas para asegurarme de que la API cumpla exactamente con tus necesidades:
+
+1. ¿La puntuación media del candidato debe calcularse solo con las entrevistas completadas, o también se incluyen entrevistas en curso o pendientes?
+2. ¿Hay algún filtro adicional que deba aplicarse a los candidatos? Por ejemplo, ¿solo los que están “en proceso” (no rechazados ni contratados)?
+3. ¿Qué estructura deseas para la respuesta? Por ejemplo, ¿un array de objetos con las propiedades: nombre, current_interview_step, average_score?
+4. ¿Hay algún requerimiento de paginación o se deben devolver todos los candidatos de la posición?
+5. ¿El endpoint debe estar autenticado o protegido de alguna manera?
+
+Con estas respuestas podré generar el código de la API de manera precisa y alineada a tus expectativas.
+
+---
+
+## Prompt 2
+1.- Solo las entrvistas completadas.
+2.- No hya filtros adicionales
+3.- Si, debería ser un array de objetos
+4.- Retorna todos lo candidatos, sin paginación
+
+---
+
+## Prompt 3
+- Debería ser el nombre del paso
+- Incluye el id y el nombre del candidato
+
+---
+
+## Prompt 4
+Funciona correctamente.
+Ahora vamos con el siguiente API:
+
+PUT /candidates/:id/stage
+Este endpoint actualizará la etapa del candidato movido. Permite modificar la fase actual del proceso de entrevista en la que se encuentra un candidato específico.
+
+igual que antes, no escribas código hasta aclarar todas las dudas.
+
+**Respuesta:**
+¡Perfecto! Antes de escribir el código, te hago algunas preguntas para asegurarme de que el endpoint cumpla exactamente con lo que necesitas:
+
+1. ¿El parámetro :id corresponde al id del candidato o al id de la aplicación (application)? (Recuerda que un candidato puede tener varias aplicaciones/posiciones).
+2. ¿El nuevo “stage” (etapa) se enviará en el body como el id del InterviewStep, o como nombre/texto?
+3. ¿Debemos validar que el nuevo stage exista y pertenezca al flujo de entrevistas de la posición correspondiente?
+4. ¿Qué respuesta esperas? ¿Solo un mensaje de éxito, o el objeto actualizado?
+5. ¿Hay alguna restricción de seguridad/autenticación para este endpoint?
+
+Con estas respuestas, podré diseñar el endpoint exactamente como lo necesitas.
+
+---
+
+## Prompt 5
+1.- Debería ser la aplicación.
+2.- Se debe enviar en el body como Id
+3.- Si, se debería validar.
+4.- Que retorne le objeto actualizado.
+5.- No hay restricciones de seguridad
+
+---
+
+## Prompt 6
+- No, solo los campos de la tabla application
+- Solo currentInterviewStep
+
+---
+
+## Prompt 7
+¡Perfecto! El endpoint quedará así:
+
+- PUT /candidates/:applicationId/stage
+- Body: { "stageId": <nuevo_id_de_stage> }
+- Actualiza solo el campo currentInterviewStep de la tabla Application.
+- Valida que el stageId pertenezca al flujo de entrevistas de la posición de la aplicación.
+- Retorna el objeto Application actualizado (solo sus campos).
+- No hay restricciones de seguridad.
+
+Voy a proceder a implementar el endpoint siguiendo estas especificaciones. ¿Listo para que lo genere?
+
+---
+
+## Prompt 8
+Si


### PR DESCRIPTION
Implementa un endpoint GET `/positions/:id/candidates` para listar candidatos por posición, incluyendo su etapa actual en el proceso y la puntuación media de sus entrevistas completadas.

Añade un endpoint PUT `/candidates/:id/stage` para actualizar la etapa de una aplicación de candidato, asegurando que la nueva etapa sea válida dentro del flujo de entrevistas de la posición.